### PR TITLE
1.1 update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,17 @@ If you feel like fixing a bug or adding some logic, clone and/or fork this repos
 
 Issues can be added to the issues tab of this repo.
 
+### Change history
+
+#### 1.0
+Initial release - mostly works if you don't mess to much with it. Has a problem finishing the script when there are a lot of symbols and charts to render.
+
+#### 1.1
+
+* For full year history, stocks now only pull approximately one data point per week (varies depending on holidays, etc.). Crypto pulls about the same give or take. This is to reduce the number of data points in the worksheets as well as for rendering charts. Full refreshes work much better now
+* For daily history, only rendering in 15-20 minute increments rather than 5 minutes. Same reason
+* Added a button and a bit of logic for refreshing just charts. If you have a lot of symbols the charts can time out on larger refreshes. The button lets you refresh charts by themselves once the rest of the data is pulled
+
 ### License
 Copyright 2019 Chris Hundley
 

--- a/scripts/alpaca.js
+++ b/scripts/alpaca.js
@@ -1,5 +1,5 @@
 /**
- * TICKER v1.0
+ * TICKER v1.1
  *
  * Interface to the Alpaca API
  *
@@ -7,7 +7,7 @@
  *
  * Rate limit: 200 requests per minute
  *
- * Copyright 2019 Chris Hundley
+ * Copyright 2019-2020 Chris Hundley
  *
  * MIT LICENSE
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation

--- a/scripts/charts.js
+++ b/scripts/charts.js
@@ -1,5 +1,5 @@
 /**
- * TICKER v1.0
+ * TICKER v1.1
  *
  * This script is a library for rendering charts for the Ticker worksheet
  *
@@ -7,7 +7,7 @@
  *   - https://developers.google.com/apps-script/reference/spreadsheet/embedded-area-chart-builder
  *   - https://developers.google.com/chart/interactive/docs/gallery/areachart#configuration-options
  *
- * Copyright 2019 Chris Hundley
+ * Copyright 2019-2020 Chris Hundley
  *
  * MIT LICENSE
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,9 +1,9 @@
 /**
- * TICKER v1.0
+ * TICKER v1.1
  *
  * Constants used throughout the Ticker scripts
  *
- * Copyright 2019 Chris Hundley
+ * Copyright 2019-2020 Chris Hundley
  *
  * MIT LICENSE
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation

--- a/scripts/cryptocompare.js
+++ b/scripts/cryptocompare.js
@@ -1,11 +1,13 @@
 /**
+ * TICKER v1.1
+ *
  * Interface to the CryptoCompare API for Google Sheets implementation
  *
  * https://min-api.cryptocompare.com/documentation
  *
  * Rate limit: 50/sec 2500/minute, 25K/hour, 100K/month
  *
- * Copyright 2019 Chris Hundley
+ * Copyright 2019-2020 Chris Hundley
  *
  * MIT LICENSE
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -1,5 +1,5 @@
 /**
- * TICKER v1.0
+ * TICKER v1.1
  *
  * Utility functions for managing/manipulating data in a Google sheet
  *
@@ -8,7 +8,7 @@
  *   - https://developers.google.com/apps-script/reference/spreadsheet/range
  *
  *
- * Copyright 2019 Chris Hundley
+ * Copyright 2019-2020 Chris Hundley
  *
  * MIT LICENSE
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation


### PR DESCRIPTION
* For full year history, stocks now only pull approximately one data point per week (varies depending on holidays, etc.). Crypto pulls about the same give or take. This is to reduce the number of data points in the worksheets as well as for rendering charts. Full refreshes work much better now
* For daily history, only rendering in 15-20 minute increments rather than 5 minutes. Same reason
* Added a button and a bit of logic for refreshing just charts. If you have a lot of symbols the charts can time out on larger refreshes. The button lets you refresh charts by themselves once the rest of the data is pulled